### PR TITLE
Add iOS quickstart docs and scanning scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -139,3 +139,10 @@ dmypy.json
 
 # Sublime Text project files
 *.sublime*
+# MVT iOS artifacts
+mvt_out/
+decrypted/
+backup/
+*.ab
+*.tgz
+*.plist

--- a/README.md
+++ b/README.md
@@ -45,6 +45,10 @@ For alternative installation options and known issues, please refer to the [docu
 
 MVT provides two commands `mvt-ios` and `mvt-android`. [Check out the documentation to learn how to use them!](https://docs.mvt.re/)
 
+### iOS scan (MVT)
+
+For a quick iOS scan guide, see [mvt-ios-quickstart](docs/mvt-ios-quickstart.md).
+
 
 ## License
 

--- a/docs/mvt-ios-quickstart.md
+++ b/docs/mvt-ios-quickstart.md
@@ -1,0 +1,44 @@
+# MVT iOS Quickstart
+
+This quickstart shows how to use [Mobile Verification Toolkit (MVT)](https://github.com/mvt-project/mvt) to scan an iOS device on macOS.
+
+## Install on macOS
+
+```sh
+# with Homebrew
+brew install mvt
+
+# or using pipx
+brew install pipx  # if pipx is not installed
+pipx install mvt
+```
+
+## Create an encrypted backup
+
+1. Connect the iOS device to the Mac.
+2. Create an **encrypted** backup using Finder or the command below:
+
+```sh
+idevicebackup2 backup --full --encrypt --password "$BACKUP_PASS" backup/
+```
+
+## Decrypt the backup
+
+```sh
+mvt-ios decrypt-backup -p "$BACKUP_PASS" -d decrypted/ backup/
+```
+
+## Fetch indicators and scan
+
+```sh
+mvt-ios download-iocs
+mvt-ios check-backup --output mvt_out decrypted/
+```
+
+## Security notes
+
+- Only analyze devices with the owner's explicit consent.
+- A match with an indicator does **not** confirm an infection.
+- Do not commit generated backups or scan results to any repository.
+
+All commands above are ready to copy and run. Adjust paths and passwords as needed.

--- a/scripts/mvt_ios_scan.sh
+++ b/scripts/mvt_ios_scan.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# Usage: ./scripts/mvt_ios_scan.sh
+set -euo pipefail
+
+BACKUP_SRC=${BACKUP_SRC:-./backup}
+BACKUP_PASS=${BACKUP_PASS:-}
+DEC=${DEC:-./decrypted}
+OUT=${OUT:-./mvt_out}
+IOCS=${IOCS:-}
+
+for dir in "$DEC" "$OUT"; do
+    if [ -e "$dir" ]; then
+        read -r -p "$dir exists. Overwrite? [y/N] " ans
+        if [[ ! $ans =~ ^[Yy]$ ]]; then
+            echo "Aborting."
+            exit 1
+        fi
+        rm -rf "$dir"
+    fi
+    mkdir -p "$dir"
+done
+
+echo "Downloading latest public IOCs..."
+mvt-ios download-iocs
+
+echo "Decrypting backup from $BACKUP_SRC..."
+if [ -n "$BACKUP_PASS" ]; then
+    mvt-ios decrypt-backup -p "$BACKUP_PASS" -d "$DEC" "$BACKUP_SRC"
+else
+    mvt-ios decrypt-backup -d "$DEC" "$BACKUP_SRC"
+fi
+
+echo "Scanning decrypted backup..."
+if [ -n "$IOCS" ]; then
+    mvt-ios check-backup --output "$OUT" --iocs "$IOCS" "$DEC"
+else
+    mvt-ios check-backup --output "$OUT" "$DEC"
+fi
+
+echo "Results saved to $OUT"

--- a/scripts/mvt_ios_summary.py
+++ b/scripts/mvt_ios_summary.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+"""Summarize MVT iOS JSON outputs."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+
+def parse_ts(value: str) -> datetime | None:
+    try:
+        return datetime.fromisoformat(value.replace("Z", "+00:00")).replace(tzinfo=None)
+    except Exception:  # pragma: no cover - best effort parsing
+        return None
+
+
+def main(out_dir: str) -> None:
+    path = Path(out_dir)
+    total = 0
+    modules: set[str] = set()
+    recent: list[str] = []
+    now = datetime.now(UTC).replace(tzinfo=None)
+    cutoff = now - timedelta(days=7)
+
+    for json_file in path.glob("*.json"):
+        try:
+            data = json.loads(json_file.read_text())
+        except Exception:
+            continue
+        if isinstance(data, list) and data:
+            total += len(data)
+            modules.add(json_file.stem)
+            for item in data:
+                ts = None
+                for key in ("timestamp", "date", "time"):
+                    val = item.get(key)
+                    if isinstance(val, str):
+                        ts = parse_ts(val)
+                        if ts:
+                            break
+                if ts and ts >= cutoff:
+                    recent.append(f"{json_file.name}: {item}")
+
+    print(f"Total matches: {total}")
+    if modules:
+        print("Modules: " + ", ".join(sorted(modules)))
+    else:
+        print("Modules: none")
+    if recent:
+        print("Matches in last 7 days:")
+        for line in recent:
+            print(f"- {line}")
+    else:
+        print("No matches in last 7 days.")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Summarize MVT iOS scan results")
+    parser.add_argument("--out", default="./mvt_out", help="Directory with JSON outputs")
+    args = parser.parse_args()
+    main(args.out)


### PR DESCRIPTION
## Summary
- document safe iOS scanning workflow for macOS users
- add helper scripts to run scans and summarise results
- ignore backup and scan artefacts

## Testing
- `shellcheck scripts/mvt_ios_scan.sh` *(fails: command not found)*
- `flake8 scripts/mvt_ios_summary.py` *(fails: command not found)*
- `pytest` *(fails: No module named 'mvt')*


------
https://chatgpt.com/codex/tasks/task_e_68a0d2434a78832fb207d0b8701994d6